### PR TITLE
Patch SplashBitmap.h to not #include with poppler/ prefix

### DIFF
--- a/alienfile
+++ b/alienfile
@@ -9,6 +9,7 @@ requires 'Alien::gmake';
 requires 'Alien::Build::Plugin::Gather::Dino';
 requires 'Alien::OpenJPEG';
 requires 'Env::ShellWords' => '0.01';
+requires 'Path::Tiny' => 0;
 use Env qw($LDFLAGS);
 
 # https://poppler.freedesktop.org/
@@ -28,6 +29,14 @@ share {
 	plugin 'Build::SearchDep' => (
 		aliens => [ qw( Alien::OpenJPEG ) ],
 	);
+
+
+	patch sub {
+		my($splash_bitmap) = Path::Tiny->new('splash/SplashBitmap.h');
+		$splash_bitmap->edit_lines(sub {
+			s{\Qpoppler/GfxState.h\E}{GfxState.h}g;
+		});
+	};
 
 	plugin 'Build::Autoconf' => ();
 	build [


### PR DESCRIPTION
This is because we install to a directory that is not under the usual
include path, so trying to use the prefix will not find the header file
even if we use the `pkg-config --cflags` to configure.


