### PR TITLE
Switch build commands to CMake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
 addons:
   apt:
     packages:
-      - cmake      # for Alien::OpenJPEG
+      - cmake
       - libjpeg-dev
       - aspell     # for dzil Test::PodSpelling
       - aspell-en  # for dzil Test::PodSpelling

--- a/alienfile
+++ b/alienfile
@@ -38,10 +38,11 @@ share {
 		});
 	};
 
-	plugin 'Build::Autoconf' => ();
 	build [
-		[ '%{configure} --enable-xpdf-headers' ],
-		[ '%{gmake}' ], # , 'V=1'
+		[ 'cmake', qw(-G), 'Unix Makefiles',
+			'-DCMAKE_INSTALL_PREFIX:PATH=%{.install.prefix}',
+			'.' ],
+		[ '%{gmake}' ],
 		[ '%{gmake}', 'install' ],
 	];
 

--- a/maint/devops.yml
+++ b/maint/devops.yml
@@ -2,9 +2,11 @@
 native:
   debian:
     packages:
+      - cmake
       - libjpeg-dev
   macos-homebrew:
     packages:
+      - cmake
       - pkg-config
       - cairo
       - fontconfig
@@ -20,4 +22,5 @@ native:
       #- openjpeg
   msys2-mingw64:
     packages:
+      - mingw-w64-x86_64-cmake
       - mingw-w64-x86_64-libjpeg-turbo

--- a/maint/devops.yml
+++ b/maint/devops.yml
@@ -24,3 +24,4 @@ native:
     packages:
       - mingw-w64-x86_64-cmake
       - mingw-w64-x86_64-libjpeg-turbo
+      - mingw-w64-x86_64-freetype


### PR DESCRIPTION
The autotools build system has been removed in `poppler-0.60.0`
(Mon Oct 2, 2017) and has been replaced with CMake as the default build
system.

Fixes <https://github.com/project-renard/p5-Alien-Poppler/issues/4>.

