### PR TITLE
Enable Xpdf headers in CMake build

### DIFF
--- a/alienfile
+++ b/alienfile
@@ -41,6 +41,7 @@ share {
 	build [
 		[ 'cmake', qw(-G), 'Unix Makefiles',
 			'-DCMAKE_INSTALL_PREFIX:PATH=%{.install.prefix}',
+			'-DENABLE_XPDF_HEADERS=ON',
 			( '-DENABLE_GLIB=OFF' )x!!( $^O eq 'darwin' ),
 			'.' ],
 		[ '%{gmake}' ],


### PR DESCRIPTION
This is so that dependent packages can use them if needed.

Fixes <https://github.com/project-renard/p5-Alien-Poppler/issues/7>.