### PR TITLE
Fix pkg-config paths in Poppler v0.61

### DIFF
--- a/alienfile
+++ b/alienfile
@@ -36,6 +36,18 @@ share {
 		$splash_bitmap->edit_lines(sub {
 			s{\Qpoppler/GfxState.h\E}{GfxState.h}g;
 		});
+
+		# Bug in Poppler v0.61: uses `@CMAKE_INSTALL_LIBDIR@` instead
+		# of either `@CMAKE_INSTALL_FULL_LIBDIR@` or
+		# `${prefix}/@CMAKE_INSTALL_LIBDIR@`.
+		my @pc_cmake_paths = Path::Tiny->new('.')->children(qr/\Q.pc.cmake\E$/);
+		for my $pc_cmake_file (@pc_cmake_paths) {
+			$pc_cmake_file->edit_lines(sub {
+				s[libdir=\@CMAKE_INSTALL_LIBDIR@][libdir=\${prefix}/\@CMAKE_INSTALL_LIBDIR@]g;
+				s[includedir=\@CMAKE_INSTALL_INCLUDEDIR@][includedir=\${prefix}/\@CMAKE_INSTALL_INCLUDEDIR@]g;
+			});
+		}
+
 	};
 
 	build [


### PR DESCRIPTION
The CMake variables used do not expand to the full path path and only
reference the last part of the path (e.g., `@CMAKE_INSTALL_INCLUDEDIR@`
becomes just `include`).

Fixes <https://github.com/project-renard/p5-Alien-Poppler/issues/9>.
